### PR TITLE
CI: Clone LuaSec to a separate folder.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
   - luarocks --local install luafilesystem
   - luarocks --local install lsqlite3 0.9.3-0
   - luarocks --local install luasocket
-  - git clone --depth=1 --branch=luasec-0.6 git://github.com/brunoos/luasec.git
-  - cd luasec && luarocks --local make OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
+  - git clone --depth=1 --branch=luasec-0.6 git://github.com/brunoos/luasec.git ~/luasec
+  - cd ~/luasec && luarocks --local make OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
   - wget -O $TRAVIS_BUILD_DIR/../InfoReg.lua https://raw.githubusercontent.com/cuberite/cuberite/master/Server/Plugins/InfoReg.lua
   - mkdir ~/AutoAPI
   - wget -O ~/AutoAPI.zip --no-check-certificate https://builds.cuberite.org/job/Cuberite%20Windows%20x64%20Master/lastSuccessfulBuild/artifact/AutoAPI.zip


### PR DESCRIPTION
`luasec` source seems to have leaked into the plugin sources.