### PR TITLE
Fixed API problems with empty cBlockArea.

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -122,11 +122,11 @@ local function CheckGallery(a_Gallery, a_Index)
 		a_Gallery.AreaSizeX = Schematic:GetSizeX();
 		a_Gallery.AreaSizeZ = Schematic:GetSizeZ();
 		a_Gallery.AreaTop   = Schematic:GetSizeY();
-		a_Gallery.AreaTemplateSchematicTop = cBlockArea();
 		if (a_Gallery.AreaTop < 255) then
+			a_Gallery.AreaTemplateSchematicTop = cBlockArea();
 			a_Gallery.AreaTemplateSchematicTop:Create(a_Gallery.AreaSizeX, 255 - a_Gallery.AreaTop, a_Gallery.AreaSizeZ);
 		else
-			a_Gallery.AreaTemplateSchematicTop:Create(a_Gallery.AreaSizeX, 0, a_Gallery.AreaSizeZ);
+			a_Gallery.AreaTemplateSchematicTop = nil
 		end
 		a_Gallery.TeleportCoordY = GetSchematicHighestNonAirBlock(Schematic) + 1;
 	else

--- a/HookHandlers.lua
+++ b/HookHandlers.lua
@@ -201,7 +201,7 @@ local function ImprintChunkWithGallery(a_MinX, a_MinZ, a_MaxX, a_MaxZ, a_ChunkDe
 	for z = FromZ, ToZ, a_Gallery.AreaSizeZ do
 		for x = FromX, ToX, a_Gallery.AreaSizeX do
 			a_ChunkDesc:WriteBlockArea(Template, x, 0, z);
-			if (a_ClearAbove) then
+			if (a_ClearAbove and TemplateTop) then
 				a_ChunkDesc:WriteBlockArea(TemplateTop, x, Top, z);
 			end
 		end

--- a/InGameCommandHandlers.lua
+++ b/InGameCommandHandlers.lua
@@ -259,7 +259,9 @@ function HandleCmdClaim(a_Split, a_Player)
 	-- Fill the area with the schematic, if available:
 	if (Gallery.AreaTemplateSchematic ~= nil) then
 		Gallery.AreaTemplateSchematic:Write   (a_Player:GetWorld(), Area.MinX, 0,               Area.MinZ)
-		Gallery.AreaTemplateSchematicTop:Write(a_Player:GetWorld(), Area.MinX, Gallery.AreaTop, Area.MinZ)
+		if (Gallery.AreaTemplateSchematicTop) then
+			Gallery.AreaTemplateSchematicTop:Write(a_Player:GetWorld(), Area.MinX, Gallery.AreaTop, Area.MinZ)
+		end
 	end
 
 	-- Teleport to the area and set orientation to look at the area:
@@ -761,11 +763,11 @@ function HandleCmdReset(a_Split, a_Player)
 		return true;
 	end
 
-	assert(TemplateTop ~= nil);
-
 	-- Reset the area:
 	Template:Write(a_Player:GetWorld(), MinX, 0, MinZ);
-	TemplateTop:Write(a_Player:GetWorld(), MinX, AreaTop, MinZ);
+	if (TemplateTop) then
+		TemplateTop:Write(a_Player:GetWorld(), MinX, AreaTop, MinZ);
+	end
 	a_Player:SendMessage("Area has been reset");
 	return true;
 end


### PR DESCRIPTION
After cuberite/cuberite#3795 is merged, API checks for `cBlockArea` have become stricter and don't support zero-size areas.