### PR TITLE
Fixed image spacing error for the preview

### DIFF
--- a/WebList.lua
+++ b/WebList.lua
@@ -463,7 +463,7 @@ local function HandleWebLatestClaims(a_Request)
 		}
 		if (g_Config.WebPreview) then
 			for rot = 0, 3 do
-				table.insert(cells, string.format("<img src=\"/~%s%s?action=getpreview&areaid=%d&rot=%d\"/>",
+				table.insert(cells, string.format("<img style='max-width: 100%%' src=\"/~%s%s?action=getpreview&areaid=%d&rot=%d\"/>",
 					requestBasePath, area.GalleryName, area.ID, rot)
 				)
 			end

--- a/WebList.lua
+++ b/WebList.lua
@@ -506,7 +506,7 @@ local function HandleWebLatestChanges(a_Request)
 		}
 		if (g_Config.WebPreview) then
 			for rot = 0, 3 do
-				table.insert(cells, string.format("<img src=\"/~%s%s?action=getpreview&areaid=%d&rot=%d\"/>",
+				table.insert(cells, string.format("<img style='max-width: 100%%' src=\"/~%s%s?action=getpreview&areaid=%d&rot=%d\"/>",
 					requestBasePath, area.GalleryName, area.ID, rot)
 				)
 			end


### PR DESCRIPTION
This pull request is a tentative fix for #68 
The issue described an off by one error in the way the images were rendered. After doing a lot of debugging and testing, I realized that this actually wasn't the case. The issue was that the images were very large, and there was padding to the left of the images due to the table in HTML. 

To fix this, I added some CSS rules to space out all of the images so that they fit on the screen. While this doesn't fix the issue of the padding on the left, it is unclear what the correct behavior should be. Based on the preexisting table headings, I am assuming that the spacing on the left is intentional and should be left as is.

Fixed version:
![Screenshot from 2019-12-10 21-28-46](https://user-images.githubusercontent.com/7073362/70586041-146cb600-1b94-11ea-94a8-e7595c22dcd3.png)


So note the spacing on the left is due to the table heading from above the image. My fix now allows all of the previews to be displayed, which made it look like an off by one error when it really wasn't.

Full screenshot:
![Screenshot from 2019-12-10 21-30-12](https://user-images.githubusercontent.com/7073362/70586119-454ceb00-1b94-11ea-8719-8a3f821cc985.png)

The large amount of vertical space is part of the original Minecraft schematic, so I wasn't able to do much about that. I would propose we delete the space above the actual build changes, if it is empty. I will look into this in a later PR.

Let me know if there are any issues!
